### PR TITLE
Morphology::getVersion also needs a export declaration.

### DIFF
--- a/brion/morphology.h
+++ b/brion/morphology.h
@@ -83,7 +83,7 @@ public:
     BRION_API Vector2isPtr readApicals() const;
 
     /** @internal */
-    MorphologyVersion getVersion() const;
+    BRION_API MorphologyVersion getVersion() const;
     //@}
 
     /** @name Write API */


### PR DESCRIPTION
Because morphologyConverter uses it.

Change-Id: I3a8bd1066f59a467cb17a8cd5cb53fc274ed98ae