### PR TITLE
Add getURI() method in SpikeReport

### DIFF
--- a/.gitsubprojects
+++ b/.gitsubprojects
@@ -1,3 +1,3 @@
 # -*- mode: cmake -*-
-git_subproject(Lunchbox https://github.com/Eyescale/Lunchbox.git 21f4ed2)
+git_subproject(Lunchbox https://github.com/Eyescale/Lunchbox.git 01507da)
 git_subproject(vmmlib https://github.com/Eyescale/vmmlib.git 2bec113)

--- a/brion/plugin/spikeReportBinary.cpp
+++ b/brion/plugin/spikeReportBinary.cpp
@@ -36,7 +36,8 @@ static const uint32_t version = 1;
 }
 
 SpikeReportBinary::SpikeReportBinary( const SpikeReportInitData& initData )
-    : _filename( initData.getURI().getPath( ))
+    : _uri( initData.getURI( ))
+    , _filename( _uri.getPath( ))
 {
     if( initData.getAccessMode() & MODE_READ )
     {
@@ -80,6 +81,11 @@ bool SpikeReportBinary::handles( const SpikeReportInitData& initData )
     const boost::filesystem::path ext =
         boost::filesystem::path( uri.getPath() ).extension();
     return ext == BINARY_REPORT_FILE_EXT;
+}
+
+const URI& SpikeReportBinary::getURI() const
+{
+    return _uri;
 }
 
 float SpikeReportBinary::getStartTime() const

--- a/brion/plugin/spikeReportBinary.h
+++ b/brion/plugin/spikeReportBinary.h
@@ -46,6 +46,9 @@ public:
     /** Check if this plugin can handle the given uri. */
     static bool handles( const SpikeReportInitData& initData );
 
+    /** @copydoc brion::SpikeReport::getURI */
+    const URI& getURI() const final;
+
     /** @copydoc brion::SpikeReport::getStartTime */
     float getStartTime() const final;
 
@@ -66,6 +69,7 @@ public:
         { return SpikeReport::STATIC; }
 
 private:
+    const URI _uri;
     const std::string _filename;
     Spikes _spikes;
 };

--- a/brion/plugin/spikeReportBluron.cpp
+++ b/brion/plugin/spikeReportBluron.cpp
@@ -38,7 +38,8 @@ namespace
 }
 
 SpikeReportBluron::SpikeReportBluron( const SpikeReportInitData& initData )
-    : _spikeReportFile( initData.getURI().getPath(), BLURON_SPIKE_REPORT,
+    : _uri( initData.getURI( ))
+    , _spikeReportFile( _uri.getPath(), BLURON_SPIKE_REPORT,
                         initData.getAccessMode( ))
 {
     if( initData.getAccessMode() == MODE_READ )
@@ -55,6 +56,11 @@ bool SpikeReportBluron::handles( const SpikeReportInitData& initData )
     const boost::filesystem::path ext =
             boost::filesystem::path( uri.getPath() ).extension();
     return ext == BLURON_REPORT_FILE_EXT;
+}
+
+const URI& SpikeReportBluron::getURI() const
+{
+    return _uri;
 }
 
 float SpikeReportBluron::getStartTime() const

--- a/brion/plugin/spikeReportBluron.h
+++ b/brion/plugin/spikeReportBluron.h
@@ -39,6 +39,9 @@ public:
     /** Check if this plugin can handle the given uri. */
     static bool handles( const SpikeReportInitData& initData );
 
+    /** @copydoc brion::SpikeReport::getURI */
+    const URI& getURI() const final;
+
     /** @copydoc brion::SpikeReport::getStartTime */
     float getStartTime() const final;
 
@@ -61,6 +64,7 @@ public:
     }
 
 private:
+    const URI _uri;
     Spikes _spikes;
     SpikeReportFile _spikeReportFile;
 };

--- a/brion/plugin/spikeReportNEST.cpp
+++ b/brion/plugin/spikeReportNEST.cpp
@@ -74,17 +74,17 @@ lunchbox::Strings expandShellWildcard( const std::string& filename )
 }
 
 SpikeReportNEST::SpikeReportNEST( const SpikeReportInitData& initData )
+    : _uri( initData.getURI( ))
 {
-    const lunchbox::URI& uri = initData.getURI();
     const int accessMode = initData.getAccessMode();
 
     if( accessMode == MODE_READ )
-        _reportFiles = expandShellWildcard( uri.getPath( ));
+        _reportFiles = expandShellWildcard( _uri.getPath( ));
 
     if( accessMode & MODE_WRITE  )
-        _reportFiles.push_back( uri.getPath( ) );
+        _reportFiles.push_back( _uri.getPath( ));
 
-    _spikeReportFiles.resize( _reportFiles.size() );
+    _spikeReportFiles.resize( _reportFiles.size( ));
 
     bool emptyReport = true;
     size_t reportIndex = 0;
@@ -108,6 +108,11 @@ SpikeReportNEST::~SpikeReportNEST()
 {
     BOOST_FOREACH( SpikeReportFile* writer, _spikeReportFiles )
        delete writer;
+}
+
+const URI& SpikeReportNEST::getURI() const
+{
+    return _uri;
 }
 
 bool SpikeReportNEST::handles( const SpikeReportInitData& initData )

--- a/brion/plugin/spikeReportNEST.h
+++ b/brion/plugin/spikeReportNEST.h
@@ -38,6 +38,9 @@ public:
     explicit SpikeReportNEST( const SpikeReportInitData& initData );
     virtual ~SpikeReportNEST();
 
+    /** @copydoc brion::SpikeReport::getURI */
+    const URI& getURI() const final;
+
     /** Check if this plugin can handle the given uri. */
     static bool handles( const SpikeReportInitData& initData );
 
@@ -63,6 +66,7 @@ public:
     }
 
 private:
+    const URI _uri;
     Spikes _spikes;
     Strings _reportFiles;
     typedef std::vector< SpikeReportFile* > SpikeReportFiles;

--- a/brion/plugin/spikeReportSimpleStreamer.cpp
+++ b/brion/plugin/spikeReportSimpleStreamer.cpp
@@ -34,7 +34,8 @@ const size_t DEFAULT_LINES_PER_BATCH = 5000;
 
 SpikeReportSimpleStreamer::SpikeReportSimpleStreamer(
                                         const SpikeReportInitData& initData )
-    : _filename( initData.getURI().getPath( ) )
+    : _uri( initData.getURI( ))
+    , _filename( _uri.getPath( ))
     , _lastTimeStamp( -1 ) // This means that nothing has been received yet
     , _lastEndTime( 0 )
 {
@@ -64,6 +65,11 @@ bool SpikeReportSimpleStreamer::handles( const SpikeReportInitData& initData )
     const boost::filesystem::path ext =
             boost::filesystem::path( uri.getPath() ).extension();
     return ext == NEST_REPORT_FILE_EXT;
+}
+
+const URI& SpikeReportSimpleStreamer::getURI() const
+{
+    return _uri;
 }
 
 float SpikeReportSimpleStreamer::getStartTime() const

--- a/brion/plugin/spikeReportSimpleStreamer.h
+++ b/brion/plugin/spikeReportSimpleStreamer.h
@@ -45,6 +45,9 @@ public:
     /** Check if this plugin can handle the given uri. */
     static bool handles( const SpikeReportInitData& initData );
 
+    /** @copydoc brion::SpikeReport::getURI */
+    const URI& getURI() const final;
+
     /** @copydoc brion::SpikeReport::getStartTime */
     float getStartTime() const final;
 
@@ -76,7 +79,8 @@ public:
     void close() final;
 
 private:
-    std::string _filename;
+    const URI _uri;
+    const std::string _filename;
 
     // This is the data set that is exposed to the user. This data set is
     // updated with cached incoming spikes by waitUntil.

--- a/brion/spikeReport.cpp
+++ b/brion/spikeReport.cpp
@@ -76,6 +76,11 @@ SpikeReport::~SpikeReport()
     delete _impl;
 }
 
+const URI& SpikeReport::getURI() const
+{
+    return _impl->plugin->getURI();
+}
+
 SpikeReport::ReadMode SpikeReport::getReadMode() const
 {
     return _impl->plugin->getReadMode();
@@ -123,7 +128,7 @@ void SpikeReport::clear( const float startTime, const float endTime )
 
 void SpikeReport::close()
 {
-    _impl->plugin->close( );
+    _impl->plugin->close();
 }
 
 }

--- a/brion/spikeReport.h
+++ b/brion/spikeReport.h
@@ -89,10 +89,20 @@ public:
      *        registered spike report plugin.
      * @version 1.4
      */
-    BRION_API explicit SpikeReport( const URI &uri, const int mode );
+    BRION_API explicit SpikeReport( const URI& uri, const int mode );
 
     /** Destructor. @version 1.3 */
     BRION_API ~SpikeReport();
+
+    /**
+     * Get the URI used to instantiate the report. It could be different from
+     * the input URI, depending on the plugin implementation.
+     *
+     * @return The URI used in the instance. It could be the same as the input
+     * URI or a different one, depending on the implementation
+     * @version 1.6
+     */
+    BRION_API const URI& getURI() const;
 
     /**
      * @version 1.4
@@ -155,7 +165,6 @@ public:
      */
     BRION_API bool waitUntil( const float timeStamp,
                               const uint32_t timeout = LB_TIMEOUT_INDEFINITE );
-
 
     /**
      * Return the time of the next spike available in the internal cache.

--- a/brion/spikeReportPlugin.h
+++ b/brion/spikeReportPlugin.h
@@ -112,6 +112,9 @@ public:
                      "Operation not supported in spike report plugin" ));
     }
 
+    /** @copydoc brion::SpikeReport::getURI */
+    virtual const URI& getURI() const = 0;
+
     /** @copydoc brion::SpikeReport::getReadMode */
     virtual SpikeReport::ReadMode getReadMode() const = 0;
 

--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -3,6 +3,8 @@ Changelog {#Changelog}
 
 ## git master {master)
 
+* [#24](https://github.com/BlueBrain/Brion/pull/24):
+  Add getURI() method in SpikeReport.
 * [#9](https://github.com/BlueBrain/Brion/issues/9):
   Extend SWC parser to support fork and end points and undefined section points.
   The Brion::SectionType enum has not been extended to include end and fork


### PR DESCRIPTION
This allows to obtain the URI that was used as input
in the constructor or a different one, depending on the
plugin implementation.
Needed in Monsteer to be able to obtain the URI in which the spikeReport is publishing spikes