### PR TITLE
Speedup brain::Circuit::getIDs()

### DIFF
--- a/brain/CMakeLists.txt
+++ b/brain/CMakeLists.txt
@@ -42,7 +42,7 @@ if(TARGET MVDTool)
 endif()
 common_library(Brain)
 if(TARGET MVDTool)
-  add_definitions(-DBRAIN_USE_MVD3)
+  target_compile_definitions(Brain PUBLIC BRAIN_USE_MVD3)
 endif()
 
 add_subdirectory(python)

--- a/brain/circuit.cpp
+++ b/brain/circuit.cpp
@@ -98,7 +98,7 @@ class Circuit::Impl
 public:
     explicit Impl( const brion::BlueConfig& config )
         : _morphologySource( config.getMorphologySource( ))
-        , _targetParsers( config.getTargets( ))
+        , _targetSources( config.getTargetSources( ))
     {}
     virtual ~Impl() {}
 
@@ -107,13 +107,19 @@ public:
     GIDSet getGIDs() const
     {
         brain::GIDSet gids;
+        brain::GIDSet::const_iterator hint = gids.begin();
         for( size_t i = 0; i < getNumNeurons(); ++i )
-            gids.insert( i + 1 );
+            hint = gids.insert( hint, i + 1 );
         return gids;
     }
 
     GIDSet getGIDs( const std::string& target ) const
     {
+        if( _targetParsers.empty( ))
+        {
+            BOOST_FOREACH( const URI& uri, _targetSources )
+                _targetParsers.push_back( brion::Target( uri.getPath( )));
+        }
         return brion::Target::parse( _targetParsers, target );
     }
 
@@ -131,7 +137,8 @@ public:
 
 private:
     const brion::URI _morphologySource;
-    const brion::Targets _targetParsers;
+    const brion::URIs _targetSources;
+    mutable brion::Targets _targetParsers;
 };
 
 class MVD2 : public Circuit::Impl

--- a/brain/types.h
+++ b/brain/types.h
@@ -43,6 +43,7 @@ using brion::GIDSet;
 using brion::SectionTypes;
 using brion::Strings;
 using brion::URI;
+using brion::URIs;
 using brion::Vector2is;
 using brion::Vector3fs;
 using brion::Vector4fs;
@@ -51,7 +52,6 @@ using brion::uint32_ts;
 
 typedef std::vector< Matrix4f > Matrix4fs;
 typedef std::vector< Quaternionf > Quaternionfs;
-typedef std::vector< URI > URIs;
 
 typedef boost::shared_ptr< SpikeReportReader > SpikeReportReaderPtr;
 typedef boost::shared_ptr< SpikeReportWriter > SpikeReportWriterPtr;

--- a/brion/blueConfig.cpp
+++ b/brion/blueConfig.cpp
@@ -237,20 +237,10 @@ const std::string& BlueConfig::get( const BlueConfigSection section,
 
 brion::Targets BlueConfig::getTargets() const
 {
-    const std::string& run = _impl->getRun();
-    brion::Targets targets;
-
-    const std::string& nrnPath =
-        get( brion::CONFIGSECTION_RUN, run, BLUECONFIG_NRN_PATH_KEY );
-    if( !nrnPath.empty( ))
-        targets.push_back( brion::Target(
-            nrnPath + "/" + CIRCUIT_TARGET_FILE ));
-
-    const std::string& targetPath =
-        get( brion::CONFIGSECTION_RUN, run, BLUECONFIG_TARGET_FILE_KEY );
-    if( !targetPath.empty( ))
-        targets.push_back( brion::Target( targetPath ));
-
+    Targets targets;
+    const URIs& uris = getTargetSources();
+    BOOST_FOREACH( const URI& uri, uris )
+        targets.push_back( Target( uri.getPath( )));
     return targets;
 }
 
@@ -332,10 +322,39 @@ URI BlueConfig::getSpikeSource() const
     return uri;
 }
 
+brion::URIs BlueConfig::getTargetSources() const
+{
+    const std::string& run = _impl->getRun();
+
+    URIs uris;
+    const std::string& nrnPath =
+        get( brion::CONFIGSECTION_RUN, run, BLUECONFIG_NRN_PATH_KEY );
+    if( !nrnPath.empty( ))
+    {
+        URI uri;
+        uri.setScheme( "file" );
+        uri.setPath( nrnPath + "/" + CIRCUIT_TARGET_FILE );
+        uris.push_back( uri );
+    }
+
+    const std::string& targetPath =
+        get( brion::CONFIGSECTION_RUN, run, BLUECONFIG_TARGET_FILE_KEY );
+    if( !targetPath.empty( ))
+    {
+        URI uri;
+        uri.setScheme( "file" );
+        uri.setPath( targetPath );
+        uris.push_back( uri );
+    }
+
+    return uris;
+}
+
 std::string BlueConfig::getCircuitTarget() const
 {
     return _impl->getCircuitTarget();
 }
+
 
 GIDSet BlueConfig::parseTarget( const std::string& target ) const
 {

--- a/brion/blueConfig.h
+++ b/brion/blueConfig.h
@@ -132,6 +132,12 @@ public:
      */
     BRION_API URI getSpikeSource() const;
 
+    /*
+     * @return the URIs to the locations of the target files.
+     * @version 1.8
+     */
+    BRION_API URIs getTargetSources() const;
+
     /**
      * @return the name of the circuit target
      * @version 1.7

--- a/brion/types.h
+++ b/brion/types.h
@@ -120,6 +120,8 @@ const float MINIMUM_VOLTAGE = -80.; //!< Lowest voltage after hyperpolarisation
 using lunchbox::Strings;
 
 using servus::URI;
+
+typedef std::vector< URI > URIs;
 }
 
 // if you have a type T in namespace N, the operator << for T needs to be in

--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -3,6 +3,8 @@ Changelog {#Changelog}
 
 # git master
 
+* [69](https://github.com/BlueBrain/Brion/pull/69):
+  Speedup brain::Circuit::getIDs(), add brion::BlueConfig::getTargetSources()
 * [63](https://github.com/BlueBrain/Brion/pull/63):
   Moved old BBPSDK/Monsteer spike report to Brain (pending refactoring)
 


### PR DESCRIPTION
Omit target parsing for full target GID retrieval, speedup std::set
insertion, see http://stackoverflow.com/a/11017353