### PR TITLE
Hide implementation details of Pydoxine generation.

### DIFF
--- a/.gitexternals
+++ b/.gitexternals
@@ -1,3 +1,3 @@
 # -*- mode: cmake -*-
-# CMake/common https://github.com/Eyescale/CMake.git 11ee9c1
-# Pydoxine https://github.com/BlueBrain/Pydoxine b9a3727
+# Pydoxine https://github.com/BlueBrain/Pydoxine 3b0783f
+# CMake/common https://github.com/Eyescale/CMake.git b53bf26

--- a/.gitsubprojects
+++ b/.gitsubprojects
@@ -1,6 +1,6 @@
 # -*- mode: cmake -*-
 git_subproject(Servus https://github.com/HBPVIS/Servus.git 001588d)
-git_subproject(Lunchbox https://github.com/Eyescale/Lunchbox.git 640cd69)
-git_subproject(Keyv https://github.com/BlueBrain/Keyv.git 8fd5f9d)
+git_subproject(Lunchbox https://github.com/Eyescale/Lunchbox.git 5a37f93)
+git_subproject(Keyv https://github.com/BlueBrain/Keyv.git 7ef03d0)
 git_subproject(vmmlib https://github.com/Eyescale/vmmlib.git caa86d8)
 git_subproject(MVDTool https://github.com/BlueBrain/MVDTool.git fa7523e)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,8 @@ set(BRION_MAINTAINER
 set(BRION_LICENSE LGPL)
 set(BRION_DEB_DEPENDS libhdf5-serial-dev libboost-date-time-dev
   libboost-filesystem-dev libboost-regex-dev libboost-system-dev
-  libboost-test-dev libboost-thread-dev)
+  libboost-test-dev libboost-thread-dev python3-sphinx python3-lxml)
+set(BRION_PORT_DEPENDS sphinx py-lxml)
 
 set(COMMON_PROJECT_DOMAIN ch.epfl.bluebrain)
 include(Common)

--- a/brain/python/CMakeLists.txt
+++ b/brain/python/CMakeLists.txt
@@ -25,6 +25,10 @@ set(BRAIN_PYTHON_SOURCES
 docstrings(BRAIN_PYTHON_SOURCES BRAIN_PUBLIC_HEADERS
   ${PROJECT_BINARY_DIR}/include)
 
+if(TARGET Brion-docstrings)
+  add_definitions(-DBRION_HAS_DOCSTRINGS)
+endif()
+
 list(APPEND BRAIN_PYTHON_SOURCES
   arrayHelpers.cpp
   spikeReportWriter.cpp

--- a/brain/python/CMakeLists.txt
+++ b/brain/python/CMakeLists.txt
@@ -25,10 +25,6 @@ set(BRAIN_PYTHON_SOURCES
 docstrings(BRAIN_PYTHON_SOURCES BRAIN_PUBLIC_HEADERS
   ${PROJECT_BINARY_DIR}/include)
 
-if(TARGET Brion-docstrings)
-  add_definitions(-DBRION_HAS_DOCSTRINGS)
-endif()
-
 list(APPEND BRAIN_PYTHON_SOURCES
   arrayHelpers.cpp
   spikeReportWriter.cpp
@@ -48,6 +44,7 @@ add_library(brain_python MODULE ${BRAIN_PYTHON_SOURCES})
 common_compile_options(brain_python)
 if(TARGET ${PROJECT_NAME}-docstrings)
   add_dependencies(brain_python Brain ${PROJECT_NAME}-docstrings)
+  target_compile_definitions(brain_python PRIVATE BRAIN_HAS_DOCSTRINGS)
 endif()
 
 target_link_libraries(brain_python

--- a/brain/python/CMakeLists.txt
+++ b/brain/python/CMakeLists.txt
@@ -22,18 +22,8 @@ set(BRAIN_PYTHON_SOURCES
   neuron/morphology.cpp
 )
 
-set(__docstrings_sources)
-set(__docstrings_headers)
-# Input files to docstrings need absolute paths.
-foreach(__header ${BRAIN_PUBLIC_HEADERS})
-  list(APPEND __docstrings_headers ${PROJECT_SOURCE_DIR}/brain/${__header})
-endforeach()
-foreach(__source ${BRAIN_PYTHON_SOURCES})
-  list(APPEND __docstrings_sources ${CMAKE_CURRENT_SOURCE_DIR}/${__source})
-endforeach()
-
-set(DOCSTRINGS_INCLUDE_PATH ${PROJECT_BINARY_DIR}/include)
-docstrings(__docstrings_sources __docstrings_headers)
+docstrings(BRAIN_PYTHON_SOURCES BRAIN_PUBLIC_HEADERS
+  ${PROJECT_BINARY_DIR}/include)
 
 list(APPEND BRAIN_PYTHON_SOURCES
   arrayHelpers.cpp

--- a/brain/python/brain.cpp
+++ b/brain/python/brain.cpp
@@ -67,7 +67,7 @@ struct URItoString
 
 BOOST_PYTHON_MODULE(_brain)
 {
-#if defined BRION_USE_SPHINX && defined BRION_USE_DOGYXGEN
+#ifdef BRION_HAS_DOCSTRINGS
     /* Only change the default Boost.Python options for documentation if we
        are going to get docstrings from doxygen. */
     boost::python::docstring_options doc_options(true, true, false);

--- a/brain/python/brain.cpp
+++ b/brain/python/brain.cpp
@@ -67,7 +67,7 @@ struct URItoString
 
 BOOST_PYTHON_MODULE(_brain)
 {
-#ifdef BRION_HAS_DOCSTRINGS
+#ifdef BRAIN_HAS_DOCSTRINGS
     /* Only change the default Boost.Python options for documentation if we
        are going to get docstrings from doxygen. */
     boost::python::docstring_options doc_options(true, true, false);


### PR DESCRIPTION
This is a typical case of making things complex: Why would the library
care that the files are absolute? Why do I need to specify the
(undocumented) include path separately? Should imo not have passed CR.