### PR TITLE
Added SpikeReport::getEndTime and supportsBackwardsSeek

### DIFF
--- a/brain/python/CMakeLists.txt
+++ b/brain/python/CMakeLists.txt
@@ -18,6 +18,7 @@ include(PythonDocstrings)
 set(BRAIN_PYTHON_SOURCES
   brain.cpp
   circuit.cpp
+  spikeReportReader.cpp
   synapses.cpp
   neuron/morphology.cpp
 )
@@ -29,7 +30,6 @@ list(APPEND BRAIN_PYTHON_SOURCES
   arrayHelpers.cpp
   helpers.cpp
   spikeReportWriter.cpp
-  spikeReportReader.cpp
   spikes.cpp
   submodules.cpp
   test.cpp

--- a/brain/python/spikeReportReader.cpp
+++ b/brain/python/spikeReportReader.cpp
@@ -19,6 +19,9 @@
 
 #include <boost/python.hpp>
 
+#include "arrayHelpers.h"
+#include "docstrings.h"
+
 #include <brain/types.h>
 #include <brain/spikeReportReader.h>
 
@@ -33,19 +36,34 @@ SpikeReportReaderPtr _initURI( const std::string& uri )
 {
     return SpikeReportReaderPtr( new SpikeReportReader( brion::URI( uri )));
 }
+
+bp::object SpikeReportReader_getSpikes(SpikeReportReader& reader,
+                                       const float startTime,
+                                       const float endTime )
+{
+    return toNumpy( reader.getSpikes( startTime, endTime ));
+}
 }
 
 void export_SpikeReportReader()
 {
 
+const auto selfarg = bp::arg( "self" );
+
 bp::class_< SpikeReportReader, boost::noncopyable >(
     "SpikeReportReader", bp::no_init )
-    .def( "__init__", bp::make_constructor( _initURI ))
-    .def( "close", &SpikeReportReader::close )        
-    .def( "getSpikes",
-          ( brion::Spikes (SpikeReportReader::* )( float, float ))
-          &SpikeReportReader::getSpikes )
-    .def( "hasEnded", &SpikeReportReader::hasEnded );
+    .def( "__init__", bp::make_constructor( _initURI ),
+          DOXY_FN( brain::SpikeReportReader::SpikeReportReader ))
+    .def( "close", &SpikeReportReader::close,
+          DOXY_FN( brain::SpikeReportReader::close ))
+    .def( "get_spikes", SpikeReportReader_getSpikes,
+          ( selfarg, bp::arg( "start_time" ), bp::arg( "stop_time" )),
+          DOXY_FN( brain::SpikeReportReader::getSpikes ))
+    .add_property( "end_time", &SpikeReportReader::getEndTime,
+                   DOXY_FN( brain::SpikeReportReader::getEndTime ))
+    .add_property( "has_ended", &SpikeReportReader::hasEnded,
+                   DOXY_FN( brain::SpikeReportReader::hasEnded ))
+    ;
 }
 
 }

--- a/brain/python/spikeReportReader.cpp
+++ b/brain/python/spikeReportReader.cpp
@@ -21,6 +21,7 @@
 
 #include "arrayHelpers.h"
 #include "docstrings.h"
+#include "helpers.h"
 
 #include <brain/types.h>
 #include <brain/spikeReportReader.h>
@@ -37,6 +38,13 @@ SpikeReportReaderPtr _initURI( const std::string& uri )
     return SpikeReportReaderPtr( new SpikeReportReader( brion::URI( uri )));
 }
 
+SpikeReportReaderPtr _initURIandGIDSet( const std::string& uri,
+                                        bp::object gids )
+{
+    return SpikeReportReaderPtr(
+        new SpikeReportReader( brion::URI( uri ), gidsFromPython( gids )));
+}
+
 bp::object SpikeReportReader_getSpikes(SpikeReportReader& reader,
                                        const float startTime,
                                        const float endTime )
@@ -50,10 +58,13 @@ void export_SpikeReportReader()
 
 const auto selfarg = bp::arg( "self" );
 
+// clang-format off
 bp::class_< SpikeReportReader, boost::noncopyable >(
     "SpikeReportReader", bp::no_init )
     .def( "__init__", bp::make_constructor( _initURI ),
-          DOXY_FN( brain::SpikeReportReader::SpikeReportReader ))
+          DOXY_FN( brain::SpikeReportReader::SpikeReportReader( const brion::URI& )))
+    .def( "__init__", bp::make_constructor( _initURIandGIDSet ),
+          DOXY_FN( brain::SpikeReportReader::SpikeReportReader( const brion::URI&, const GIDSet& )))
     .def( "close", &SpikeReportReader::close,
           DOXY_FN( brain::SpikeReportReader::close ))
     .def( "get_spikes", SpikeReportReader_getSpikes,
@@ -64,6 +75,7 @@ bp::class_< SpikeReportReader, boost::noncopyable >(
     .add_property( "has_ended", &SpikeReportReader::hasEnded,
                    DOXY_FN( brain::SpikeReportReader::hasEnded ))
     ;
+// clang-format on
 }
 
 }

--- a/brain/python/test.cpp
+++ b/brain/python/test.cpp
@@ -35,11 +35,12 @@ void export_test()
     for( const auto& config : bbp::test::getBlueconfigs( ))
         configs.append( config );
 
-    boost::python::scope test = brain::exportSubmodule("test");
+    boost::python::scope test = brain::exportSubmodule( "test" );
 
     test.attr("blue_config") = bbp::test::getBlueconfig();
     test.attr("blue_configs") = configs;
     test.attr("circuit_config") = bbp::test::getCircuitconfig();
+    test.attr("root_data_path") = std::string( BBP_TESTDATA );
 }
 
 }

--- a/brain/spikeReportReader.cpp
+++ b/brain/spikeReportReader.cpp
@@ -33,12 +33,22 @@ public:
         : _report( uri, brion::MODE_READ )
     {}
 
+    _Impl( const brion::URI& uri, const GIDSet& subset )
+        : _report( uri, subset )
+    {}
+
     brion::SpikeReport _report;
     brion::Spikes _collected;
 };
 
 SpikeReportReader::SpikeReportReader( const brion::URI& uri )
     : _impl( new _Impl( uri ))
+{
+}
+
+SpikeReportReader::SpikeReportReader( const brion::URI& uri,
+                                      const GIDSet& subset )
+    : _impl( new _Impl( uri, subset ))
 {
 }
 

--- a/brain/spikeReportReader.h
+++ b/brain/spikeReportReader.h
@@ -22,8 +22,10 @@
 #ifndef BRAIN_SPIKEREPORTREADER_H
 #define BRAIN_SPIKEREPORTREADER_H
 
+#include <brain/api.h>
+#include <brain/types.h>
+
 #include <boost/noncopyable.hpp>
-#include <brion/types.h>
 
 namespace brain
 {
@@ -45,13 +47,13 @@ public:
      * @version 1.0
      * @throw std::runtime_error if source is invalid.
      */
-    explicit SpikeReportReader( const brion::URI& uri );
+    BRAIN_API explicit SpikeReportReader( const brion::URI& uri );
 
     /**
      * Destructor.
      * @version 1.0
      */
-    ~SpikeReportReader();
+    BRAIN_API ~SpikeReportReader();
 
     /**
      * Get all spikes inside a time window.
@@ -64,7 +66,17 @@ public:
      * @throw std::logic_error if the precondition is not fulfilled.
      * @version 1.0
      */
-    brion::Spikes getSpikes( const float start, const float end );
+    BRAIN_API Spikes getSpikes( const float start, const float end );
+
+    /**
+     * @return the end timestamp of the report. This is the timestamp of the
+     *         last spike known to be available or larger if the implementation
+     *         has more metadata available.
+     *         For stream reports this time is 0 and it is updated when
+     *         getSpikes is called.
+     * @version 1.0
+     */
+     BRAIN_API float getEndTime() const;
 
     /**
      * @return true if any of the versions of getSpikes() reaches the end
@@ -72,8 +84,7 @@ public:
                called.
      * @version 1.0
      */
-    bool hasEnded() const;
-
+    BRAIN_API bool hasEnded() const;
 
     /**
      * Close the data source.
@@ -85,7 +96,7 @@ public:
      *
      * @version 1.0
      */
-    void close();
+    BRAIN_API void close();
 
 private:
     class _Impl;

--- a/brain/spikeReportReader.h
+++ b/brain/spikeReportReader.h
@@ -50,6 +50,17 @@ public:
     BRAIN_API explicit SpikeReportReader( const brion::URI& uri );
 
     /**
+     * Construct a new reader opening a spike data source.
+     * @param uri URI to spike report (can contain a wildcard to specify several
+     * files).
+     * @param subset Subset of cells to be reported.
+     * files).
+     * @version 1.0
+     * @throw std::runtime_error if source is invalid.
+     */
+    BRAIN_API SpikeReportReader( const brion::URI& uri, const GIDSet& subset );
+
+    /**
      * Destructor.
      * @version 1.0
      */

--- a/brain/spikeReportWriter.h
+++ b/brain/spikeReportWriter.h
@@ -60,7 +60,7 @@ public:
      * @param spikes Spikes to write.
      * @version 1.0
      */
-    void writeSpikes( const brion::Spikes& spikes );
+    void writeSpikes( const Spikes& spikes );
 
     /**
      * Get the URI where the writer is publishing. It could be same as the one

--- a/brain/types.h
+++ b/brain/types.h
@@ -41,7 +41,6 @@ enum class SynapsePrefetch
 };
 
 class Circuit;
-class Spikes;
 class SpikeReportReader;
 class SpikeReportWriter;
 class Synapse;
@@ -67,6 +66,8 @@ using brion::uint32_ts;
 using brion::size_ts;
 
 using brion::SectionOffsets;
+using brion::Spike;
+using brion::Spikes;
 using brion::CompartmentCounts;
 
 typedef std::vector< Matrix4f > Matrix4fs;

--- a/brion/plugin/spikeReportASCII.cpp
+++ b/brion/plugin/spikeReportASCII.cpp
@@ -29,6 +29,7 @@
 #include <lunchbox/stdExt.h>
 
 #include <fstream>
+#include <cmath>
 
 namespace brion
 {
@@ -248,8 +249,10 @@ void SpikeReportASCII::append( const Spikes& spikes, const WriteFunc& writefunc 
 
     file.flush();
 
-    _currentTime = spikes.rbegin()->first +
-                   std::numeric_limits< float >::epsilon();
+    const float lastTimestamp = spikes.rbegin()->first;
+    _currentTime = std::nextafter( lastTimestamp,
+                                   std::numeric_limits< float >::max( ));
+    _endTime = std::max(_endTime, lastTimestamp);
 }
 
 }

--- a/brion/plugin/spikeReportASCII.h
+++ b/brion/plugin/spikeReportASCII.h
@@ -40,6 +40,7 @@ public:
     Spikes readUntil(float toTimeStamp) final;
     void readSeek(float toTimeStamp) final;
     void writeSeek(float toTimeStamp) final;
+    bool supportsBackwardSeek() const final { return true; }
 
 protected:
     Spikes _spikes;

--- a/brion/plugin/spikeReportBinary.h
+++ b/brion/plugin/spikeReportBinary.h
@@ -52,6 +52,7 @@ public:
     void readSeek( float toTimeStamp ) final;
     void writeSeek( float toTimeStamp ) final;
     void write( const Spikes& spikes ) final;
+    bool supportsBackwardSeek() const final { return true; }
 
 private:
     std::unique_ptr< BinaryReportMap > _memFile;

--- a/brion/plugin/spikeReportBluron.cpp
+++ b/brion/plugin/spikeReportBluron.cpp
@@ -56,6 +56,9 @@ SpikeReportBluron::SpikeReportBluron( const SpikeReportInitData& initData )
     }
 
     _lastReadPosition = _spikes.begin();
+
+    if( !_spikes.empty( ))
+        _endTime = _spikes.rbegin()->first;
 }
 
 bool SpikeReportBluron::handles( const SpikeReportInitData& initData )

--- a/brion/plugin/spikeReportNEST.cpp
+++ b/brion/plugin/spikeReportNEST.cpp
@@ -99,6 +99,8 @@ SpikeReportNEST::SpikeReportNEST( const SpikeReportInitData& initData )
     }
 
     _lastReadPosition = _spikes.begin();
+    if( !_spikes.empty( ))
+        _endTime = _spikes.rbegin()->first;
 }
 
 bool SpikeReportNEST::handles( const SpikeReportInitData& initData )

--- a/brion/plugin/spikeReportNEST.h
+++ b/brion/plugin/spikeReportNEST.h
@@ -40,7 +40,7 @@ public:
     static std::string getDescription();
 
     void close() final;
-    virtual void write( const Spikes& spikes ) final;
+    void write( const Spikes& spikes ) final;
 };
 }
 }

--- a/brion/spikeReport.cpp
+++ b/brion/spikeReport.cpp
@@ -180,12 +180,6 @@ std::future< Spikes > SpikeReport::read( float min )
     _impl->plugin->_checkCanRead();
     _impl->plugin->_checkStateOk();
 
-    if ( min < getCurrentTime() )
-    {
-        LBTHROW( std::logic_error(
-            "Can't read to a time stamp inferior to the current time" ) );
-    }
-
     if ( _impl->threadPool.hasPendingJobs() )
     {
         LBTHROW( std::runtime_error( "Can't read: Pending read operation" ) );

--- a/brion/spikeReport.cpp
+++ b/brion/spikeReport.cpp
@@ -148,6 +148,11 @@ float SpikeReport::getCurrentTime() const
     return _impl->plugin->getCurrentTime();
 }
 
+float SpikeReport::getEndTime() const
+{
+    return _impl->plugin->getEndTime();
+}
+
 SpikeReport::State SpikeReport::getState() const
 {
     return _impl->plugin->getState();
@@ -255,5 +260,10 @@ void SpikeReport::write( const Spikes& spikes )
     }        
 
     _impl->plugin->write( spikes );
+}
+
+bool SpikeReport::supportsBackwardSeek() const
+{
+    return _impl->plugin->supportsBackwardSeek();
 }
 }

--- a/brion/spikeReport.h
+++ b/brion/spikeReport.h
@@ -161,6 +161,16 @@ public:
     BRION_API float getCurrentTime() const;
 
     /**
+     * @return the end timestamp of the report. This is the timestamp of the
+     *         last spike known to be available or written or larger if the
+     *         implementation has more metadata available.
+     *         For stream reports this time is 0 before any operation is
+     *         completed.
+     * @version 2.0
+     */
+    BRION_API float getEndTime() const;
+
+    /**
      * @return The state after the last completed operation.
      * @version 2.0
      */
@@ -284,6 +294,12 @@ public:
      * @version 2.0
      */
     BRION_API void write( const Spikes& spikes );
+
+    /**
+     * @return Whether the report supports seek to t < getCurrentTime() or not.
+     * @version 2.0
+     */
+    BRION_API bool supportsBackwardSeek() const;
 
 private:
     std::unique_ptr< detail::SpikeReport > _impl;

--- a/brion/spikeReport.h
+++ b/brion/spikeReport.h
@@ -189,7 +189,6 @@ public:
      * - The report was open in read mode.
      * - There is no previous read or seek operation with a pending
      *   future.
-     * - min >= getCurrentTime() or UNDEFINED_TIMESTAMP.
      *
      * Postconditions:
      * Let:

--- a/brion/spikeReportPlugin.h
+++ b/brion/spikeReportPlugin.h
@@ -139,6 +139,9 @@ public:
                      "Operation not supported in spike report plugin" ));
     }
 
+    /** @copydoc brion::SpikeReport::supportsBackwardSeek */
+    virtual bool supportsBackwardSeek() const = 0;
+
     void setFilter( const GIDSet& ids )
     {
         _idsSubset = ids;
@@ -168,6 +171,11 @@ public:
         return _currentTime;
     }
 
+    virtual float getEndTime() const
+    {
+        return _endTime;
+    }
+
     bool isClosed() const
     {
         return  _closed;
@@ -187,6 +195,7 @@ protected:
     brion::GIDSet _idsSubset;
     int _accessMode = brion::MODE_READ;
     float _currentTime = 0;
+    float _endTime = 0;
     State _state = State::ok;
 
     void pushBack( const Spike& spike, Spikes& spikes ) const

--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -3,6 +3,10 @@ Changelog {#Changelog}
 
 # git master
 
+* [120](https://github.com/BlueBrain/Brion/pull/120), [131](https://github.com/BlueBrain/Brion/pull/131):
+  - New SpikeReport API.
+  - Reimplementation of the high level SpikeReportReader. The new implementation
+    uses numpy arrays to provide the requested spikes.
 * [126](https://github.com/BlueBrain/Brion/pull/126):
   Add erase for map compartment reports
 * [122](https://github.com/BlueBrain/Brion/pull/122):

--- a/tests/brain/python/CMakeLists.txt
+++ b/tests/brain/python/CMakeLists.txt
@@ -3,7 +3,7 @@
 #
 # This file is part of Brion <https://github.com/BlueBrain/Brion>
 #
-# Change this number when adding tests to force a CMake run: 1
+# Change this number when adding tests to force a CMake run: 2
 
 if(NOT TARGET BBPTestData OR NOT TARGET brain_python)
   return()

--- a/tests/brain/python/spikes.py
+++ b/tests/brain/python/spikes.py
@@ -54,6 +54,13 @@ class TestSpikeReportReader(unittest.TestCase):
         assert(spikes[0][0] >= 7)
         assert(spikes[-1][0] < 9)
 
+    def test_get_spikes_filtered(self):
+        gids = {1, 10, 100}
+        reader = brain.SpikeReportReader(self.filename, gids)
+        spikes = reader.get_spikes(0, float("inf"))
+        for time, gid in spikes:
+            assert(gid in gids)
+
     def test_properties(self):
         reader = brain.SpikeReportReader(self.filename)
         # assertAlmostEqual fails due to a float <-> double conversion error

--- a/tests/brain/python/spikes.py
+++ b/tests/brain/python/spikes.py
@@ -1,0 +1,72 @@
+# Copyright (c) 2017, EPFL/Blue Brain Project
+#                     Juan Hernando <juan.hernando@epfl.ch>
+#
+# This file is part of Brion <https://github.com/BlueBrain/Brion>
+#
+# This library is free software; you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License version 3.0 as published
+# by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+import setup
+
+import os
+import numpy
+import brain
+
+import unittest
+
+class TestSpikeReportReader(unittest.TestCase):
+
+    def setUp(self):
+        self.filename = brain.test.root_data_path + \
+                        "/local/simulations/may17_2011/Control/out.spikes"
+
+    def test_creation_bad(self):
+        self.assertRaises(RuntimeError, lambda: brain.SpikeReportReader("foo"))
+
+    def test_creation(self):
+        reader = brain.SpikeReportReader(self.filename)
+
+    def test_get_spikes_bad(self):
+        reader = brain.SpikeReportReader(self.filename)
+        self.assertRaises(RuntimeError, lambda: reader.get_spikes(0, 0))
+        self.assertRaises(RuntimeError, lambda: reader.get_spikes(0, -1))
+
+    def test_get_spikes(self):
+        reader = brain.SpikeReportReader(self.filename)
+        spikes = reader.get_spikes(-10, 0)
+        assert(len(spikes) == 0)
+
+        spikes = reader.get_spikes(1, 5)
+        assert(spikes[0][0] >= 1)
+        assert(spikes[-1][0] < 5)
+
+        spikes = reader.get_spikes(7, 9)
+        assert(spikes[0][0] >= 7)
+        assert(spikes[-1][0] < 9)
+
+    def test_properties(self):
+        reader = brain.SpikeReportReader(self.filename)
+        # assertAlmostEqual fails due to a float <-> double conversion error
+        assert(round(reader.end_time - 9.975, 6) == 0)
+
+        # Until some read operation beyond the end is performed the report is
+        # not ended
+        assert(not reader.has_ended)
+        # numpy.nextafter(reader.end_time) should be sufficient, but the result
+        # can't be distinguished from end_time after demoted to float in the C++
+        # side.
+        spikes = reader.get_spikes(0, float("inf"))
+        assert(reader.has_ended)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/brain/spikeReportReaderWriter.cpp
+++ b/tests/brain/spikeReportReaderWriter.cpp
@@ -102,7 +102,7 @@ BOOST_AUTO_TEST_CASE( test_simple_load_static )
 
 
 
-BOOST_AUTO_TEST_CASE( test_simple_read )
+BOOST_AUTO_TEST_CASE( test_simple_read_bluron )
 {
     boost::filesystem::path path( BBP_TESTDATA );
     path /= BLURON_SPIKE_REPORT_FILE;
@@ -119,6 +119,35 @@ BOOST_AUTO_TEST_CASE( test_simple_read )
     BOOST_CHECK_EQUAL( ( --spikes.end( ))->second, BLURON_LAST_SPIKE_GID );
 }
 
+BOOST_AUTO_TEST_CASE( test_simple_read_nest )
+{
+    boost::filesystem::path path( BBP_TESTDATA );
+    path /= NEST_SPIKE_REPORT_FILE;
+
+    brain::SpikeReportReader reader( brion::URI( path.string( )));
+    const brion::Spikes& spikes = reader.getSpikes(0,brion::UNDEFINED_TIMESTAMP);
+
+    BOOST_REQUIRE_EQUAL( spikes.size(), NEST_SPIKES_COUNT );
+
+    BOOST_CHECK_EQUAL( spikes.begin()->first, NEST_FIRST_SPIKE_TIME );
+    BOOST_CHECK_EQUAL( spikes.begin()->second, NEST_FIRST_SPIKE_GID );
+
+    BOOST_CHECK_EQUAL( ( --spikes.end( ))->first, NEST_LAST_SPIKE_TIME );
+    BOOST_CHECK_EQUAL( ( --spikes.end( ))->second, NEST_LAST_SPIKE_GID );
+}
+
+BOOST_AUTO_TEST_CASE( test_simple_read_filtered )
+{
+    boost::filesystem::path path( BBP_TESTDATA );
+    path /= BLURON_SPIKE_REPORT_FILE;
+
+    brain::GIDSet gids{ 1, 10, 100 };
+    brain::SpikeReportReader reader( brion::URI( path.string( )), gids );
+    const auto spikes = reader.getSpikes(0,brion::UNDEFINED_TIMESTAMP);
+    BOOST_REQUIRE( !spikes.empty( ));
+    for (auto spike : spikes )
+        BOOST_CHECK( gids.find( spike.second ) != gids.end());
+}
 
 BOOST_AUTO_TEST_CASE( test_closed_window )
 {
@@ -138,24 +167,6 @@ BOOST_AUTO_TEST_CASE( test_out_of_window )
     const float start = spikes.back().first + 1;
 
     BOOST_CHECK_THROW( reader.getSpikes(start, start + 1 ), std::logic_error );
-}
-
-BOOST_AUTO_TEST_CASE( test_simple_stream_read )
-{
-    boost::filesystem::path path( BBP_TESTDATA );
-    path /= NEST_SPIKE_REPORT_FILE;
-
-    brain::SpikeReportReader reader( brion::URI( path.string( )));
-
-    const brion::Spikes& spikes = reader.getSpikes(0,brion::UNDEFINED_TIMESTAMP);
-
-    BOOST_REQUIRE_EQUAL( spikes.size(), NEST_SPIKES_COUNT );
-
-    BOOST_CHECK_EQUAL( spikes.begin()->first, NEST_FIRST_SPIKE_TIME );
-    BOOST_CHECK_EQUAL( spikes.begin()->second, NEST_FIRST_SPIKE_GID );
-
-    BOOST_CHECK_EQUAL( ( --spikes.end( ))->first, NEST_LAST_SPIKE_TIME );
-    BOOST_CHECK_EQUAL( ( --spikes.end( ))->second, NEST_LAST_SPIKE_GID );
 }
 
 BOOST_AUTO_TEST_CASE( test_moving_window )

--- a/tests/brain/spikeReportReaderWriter.cpp
+++ b/tests/brain/spikeReportReaderWriter.cpp
@@ -173,7 +173,7 @@ BOOST_AUTO_TEST_CASE( test_moving_window )
         {
 
             BOOST_CHECK( spikes.begin()->first >= start );
-            BOOST_CHECK( ( --spikes.end( ))->first >= start );
+            BOOST_CHECK( spikes.rbegin()->first < start + 1 );
         }
         start += 1;
     }

--- a/tests/spikeReport.cpp
+++ b/tests/spikeReport.cpp
@@ -538,7 +538,7 @@ inline void testInvalidRead(const char * format)
                                    brion::MODE_READ };
     reportRead.readUntil( 0.3 ).get();
 
-    BOOST_CHECK_THROW( reportRead.read( 0.1 ), std::logic_error );
+    BOOST_CHECK_NO_THROW( reportRead.read( 0.1 ));
     BOOST_CHECK_THROW( reportRead.readUntil( 0.1 ), std::logic_error );
 }
 


### PR DESCRIPTION
Enable caching of spikes in SpikeReportReader for reports that don't support
backward seek.
Fix SpikeReportReader wrapping with latest API.
- Make getSpikes return a numpy array with dtype "f4, u4" for spikes.
- Added docstrings.