### PR TITLE
Return GIDs in order in the wrapping of view.

### DIFF
--- a/brain/compartmentReportMapping.h
+++ b/brain/compartmentReportMapping.h
@@ -62,7 +62,8 @@ public:
      * simulation frame buffer.
      * For instance, getOffsets()[1][15] retrieves the lookup index for the
      * frame buffer for section 15 of neuron with index 1. The neuron index is
-     * derived from the order in the GID set provided in the view constructor.
+     * derived from its positions in the sorted list of GIDs provided in the
+     * view constructor.
      *
      * @return the offset for each section for each neuron
      * @version 2.0

--- a/brain/python/compartmentReport.cpp
+++ b/brain/python/compartmentReport.cpp
@@ -96,7 +96,7 @@ bp::object CompartmentReport_getMetaData(const CompartmentReport& reader)
 
 bp::object CompartmentReportView_getGids(const CompartmentReportView& view)
 {
-    return toPythonSet(view.getGIDs());
+    return toNumpy(toVector(view.getGIDs()));
 }
 
 CompartmentReportMappingProxy CompartmentReportView_getMapping(

--- a/tests/brain/python/compartmentReport.py
+++ b/tests/brain/python/compartmentReport.py
@@ -41,7 +41,7 @@ class TestReader(unittest.TestCase):
 
     def test_create_view(self):
         view = self.report.create_view({1, 2, 3})
-        assert(view.gids == {1, 2, 3})
+        assert((view.gids == [1, 2, 3]).all())
 
     def test_mapping(self):
         view = self.report.create_view({1, 2, 3})
@@ -116,7 +116,7 @@ class TestMemoryManagement(unittest.TestCase):
 
     def test_view(self):
         view = CompartmentReport(report_path).create_view({1, 2, 3})
-        assert(view.gids == {1, 2, 3})
+        assert((view.gids == [1, 2, 3]).all())
 
     def test_frame(self):
         timestamp, frame = CompartmentReport(report_path).create_view(


### PR DESCRIPTION
This facilitates finding out the index of each neurons in the mapping.