### PR TITLE
Moved gids to a separate brain.CompartmentReport property

### DIFF
--- a/brain/compartmentReport.cpp
+++ b/brain/compartmentReport.cpp
@@ -37,6 +37,11 @@ const CompartmentReportMetaData& CompartmentReport::getMetaData() const
     return _impl->metaData;
 }
 
+const brion::GIDSet& CompartmentReport::getGIDs() const
+{
+    return _impl->gids;
+}
+
 CompartmentReportView CompartmentReport::createView(const brion::GIDSet& cells)
 {
     return CompartmentReportView(_impl, cells);

--- a/brain/compartmentReport.h
+++ b/brain/compartmentReport.h
@@ -58,9 +58,6 @@ struct CompartmentReportMetaData
     /** The cell count of the report */
     size_t cellCount;
 
-    /** The gids in the report */
-    brion::GIDSet gids;
-
     /** The total frame count in the report */
     size_t frameCount;
 
@@ -103,10 +100,12 @@ public:
      * - *compartment_count* (Numeric) : The total compartment count in the
      * report
      * - *frame_count* (Numeric) : The total frame count in the report
-     * - *gids* (Vector) : The gids in the report
     */
     dict getMetaData() const;
 #endif
+
+    /** @return the GIDs of the report */
+    BRAIN_API const brion::GIDSet& getGIDs() const;
 
     /**
      * Create a view of a subset of neurons. An empty gid

--- a/brain/detail/compartmentReport.h
+++ b/brain/detail/compartmentReport.h
@@ -37,18 +37,20 @@ struct CompartmentReportReader
     {
         const brion::CompartmentReport report{uri, brion::MODE_READ};
 
+        gids = report.getGIDs();
+
         metaData.startTime = report.getStartTime();
         metaData.endTime = report.getEndTime();
         metaData.timeStep = report.getTimestep();
         metaData.timeUnit = report.getTimeUnit();
         metaData.dataUnit = report.getDataUnit();
-        metaData.gids = report.getGIDs();
-        metaData.cellCount = metaData.gids.size();
+        metaData.cellCount = gids.size();
         metaData.compartmentCount = report.getFrameSize();
         metaData.frameCount = report.getFrameCount();
     }
 
     const brion::URI uri;
+    brion::GIDSet gids;
     CompartmentReportMetaData metaData;
     lunchbox::ThreadPool threadPool;
 };

--- a/brain/python/compartmentReport.cpp
+++ b/brain/python/compartmentReport.cpp
@@ -181,7 +181,7 @@ bp::class_<CompartmentReport, boost::noncopyable>(
          DOXY_FN(brain::CompartmentReport::CompartmentReport))
     .add_property("metadata", CompartmentReport_getMetaData,
                   DOXY_FN(brain::CompartmentReport::getMetaData))
-	  .add_property("gids", CompartmentReport_getGids,
+    .add_property("gids", CompartmentReport_getGids,
                   DOXY_FN(brain::CompartmentReport::getGIDs))
     .def("create_view", CompartmentReport_createView,
          (selfarg, bp::arg("gids")),

--- a/brain/python/compartmentReport.cpp
+++ b/brain/python/compartmentReport.cpp
@@ -93,9 +93,13 @@ bp::object CompartmentReport_getMetaData(const CompartmentReport& reader)
     dict["cell_count"] = md.cellCount;
     dict["compartment_count"] = md.compartmentCount;
     dict["frame_count"] = md.frameCount;
-    dict["gids"] = toNumpy(toVector(md.gids));
 
     return dict;
+}
+
+bp::object CompartmentReport_getGids(const CompartmentReport& report)
+{
+    return toNumpy(toVector(report.getGIDs()));
 }
 
 bp::object CompartmentReportView_getGids(const CompartmentReportView& view)
@@ -177,6 +181,8 @@ bp::class_<CompartmentReport, boost::noncopyable>(
          DOXY_FN(brain::CompartmentReport::CompartmentReport))
     .add_property("metadata", CompartmentReport_getMetaData,
                   DOXY_FN(brain::CompartmentReport::getMetaData))
+	  .add_property("gids", CompartmentReport_getGids,
+                  DOXY_FN(brain::CompartmentReport::getGIDs))
     .def("create_view", CompartmentReport_createView,
          (selfarg, bp::arg("gids")),
          DOXY_FN(brain::CompartmentReport::createView(const GIDSet&)))

--- a/tests/brain/python/compartmentReport.py
+++ b/tests/brain/python/compartmentReport.py
@@ -58,8 +58,9 @@ class TestReader(unittest.TestCase):
         assert(metadata['compartment_count'] == 600)
         assert(metadata['frame_count'] == 100)
         assert(metadata['cell_count'] == 600)
-        assert((metadata['gids'] == numpy.arange(1, 601, 1)).all())
 
+    def test_gids(self):
+        assert((self.report.gids == numpy.arange(1, 601, 1)).all())
 
     def test_create_view(self):
         view = self.report.create_view({1, 2, 3})


### PR DESCRIPTION
BluePy exposes list of report GIDs as a separate property for two reasons:
1) it is the one used most frequently (others are used either internally or for debug purposes)
2) it is the one in common with SpikeReport
While it's trivial to split metadata dict into list of GIDs and other keys, I'd like to reduce to the minimum data juggling between brain and BluePy, so unless you have a strong preference here, let's have a separate property for GIDs.