### PR TITLE
Fixes for compartment reports

### DIFF
--- a/brain/python/compartmentReport.cpp
+++ b/brain/python/compartmentReport.cpp
@@ -55,6 +55,11 @@ public:
 
     size_t getNumCompartments(const size_t index) const
     {
+        if (index >= view->getMapping().getOffsets().size())
+        {
+            PyErr_SetString(PyExc_IndexError, "Cell index out of bounds");
+            throw bp::error_already_set();
+        }
         return view->getMapping().getNumCompartments(index);
     }
 

--- a/brion/compartmentReport.h
+++ b/brion/compartmentReport.h
@@ -236,6 +236,7 @@ public:
      *
      * This should only be called after all the required mapping has been saved
      * before.
+     * Values must be ordered by section and compartment.
      *
      * @param gid the GID of the cell
      * @param values the values per compartment to save
@@ -249,7 +250,8 @@ public:
     }
 
     // clang-format off
-    /** @overload brion::CompartmentReport::writeFrame(uint32_t gid, const floats& values, double timestamp) */
+    /** @overload brion::CompartmentReport::writeFrame(uint32_t gid, const
+     * floats& values, double timestamp) */
     BRION_API bool writeFrame(uint32_t gid, const float* values, size_t size,
                               double timestamp);
     // clang-format on

--- a/brion/plugin/compartmentReportCommon.cpp
+++ b/brion/plugin/compartmentReportCommon.cpp
@@ -114,7 +114,7 @@ Frames CompartmentReportCommon::loadFrames(double start, double end) const
 
     frames.timeStamps.reset(new std::vector<double>);
     for (size_t i = 0; i < count; ++i)
-        frames.timeStamps->push_back((i + startFrame) * timestep);
+        frames.timeStamps->push_back(startTime + (i + startFrame) * timestep);
 
     const auto frameSize = getFrameSize();
     frames.data.reset(new floats(frameSize * count));

--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -3,7 +3,18 @@ Changelog {#Changelog}
 
 # git master
 
-* [173](https://github.com/BlueBrain/Brion/pull/173):
+* [180](https://github.com/BlueBrain/Brion/pull/180):
+  Bugfixes in compartment reports:
+  - The report converter was messing up the order of the data when writing to
+    .h5 from an out-of-order binary.
+  - Timestamps reported were wrong for reports not starting at 0.
+  - Read time and data unit attributes from H5 reports is they exist.
+  - Do not assume the first section is always present post-processing the
+    mapping in H5 reports.
+  - Avoid crashing when calling getNumCompartments from Python with and out of
+    bounds index.
+  - Corrections in compartmentReport comparison code.
+* [176](https://github.com/BlueBrain/Brion/pull/176):
   Removed the dependency on HDF5++ and use HighFive instead.
 * [172](https://github.com/BlueBrain/Brion/pull/172):
   - zeroeq::Server/Client based morphology loader.


### PR DESCRIPTION
Fixed a regression introduced in c656928 in the report converter.
Fixed timestamps for reports not starting at 0.
Read time and data unit attributes from H5 reports.
Do not assume the first section is always present post-processing the
mapping in H5 reports.
Avoid crashing with out of bound indices in getNumCompartments.
Make comparison code in compartment report converter section order
independent.