### PR TITLE
Do not post from a thredPool thread into the same pool

### DIFF
--- a/CMake/CPackConfig.cmake
+++ b/CMake/CPackConfig.cmake
@@ -6,9 +6,16 @@
 
 set(CPACK_PACKAGE_DESCRIPTION_FILE "${PROJECT_SOURCE_DIR}/README.md")
 
-set(CPACK_DEBIAN_PACKAGE_DEPENDS "libboost-filesystem-dev, libboost-regex-dev,
-  libboost-serialization-dev, libboost-system-dev, libboost-test-dev,
-  libhdf5-serial-dev, ${LUNCHBOX_DEB_DEV_DEPENDENCY},
-  ${VMMLIB_DEB_DEV_DEPENDENCY}")
+set(BRION_PACKAGE_DEB_DEPENDS libboost-filesystem-dev libboost-regex-dev
+  libboost-serialization-dev libboost-system-dev libboost-test-dev
+  libhdf5-serial-dev)
+if(USE_PYTHON3)
+  set(PYTHON_SUFFIX 3)
+endif()
+
+if(TARGET brain_python)
+  list(APPEND CPACK_DEBIAN_PACKAGE_DEPENDS libboost-python-dev
+    python${PYTHON_SUFFIX}-numpy)
+endif()
 
 include(CommonCPack)


### PR DESCRIPTION
This was done in the compartment report reading code and can lead
to a trivial deadlock if the pool doesn't have enough threads that
can finish their tasks before the new task is posted.
A trivial case is when the hardware concurrency is 1.