### PR TITLE
Using curl instead of wget.

### DIFF
--- a/packaging/python_wheel/Dockerfile
+++ b/packaging/python_wheel/Dockerfile
@@ -7,7 +7,7 @@ RUN yum install -y zlib-devel bzip2-devel flex
 
 # Need to build this from source, since the binaries from Kitware don't
 # run with the old version of the libraries in this Centos version
-RUN wget --no-check-certificate http://cmake.org/files/v3.7/cmake-3.7.2.tar.gz && tar xfz cmake-3.7.2.tar.gz && cd cmake-3.7.2 && ./configure && make -j2 install
+RUN curl -OL https://cmake.org/files/v3.7/cmake-3.7.2.tar.gz && tar xfz cmake-3.7.2.tar.gz && cd cmake-3.7.2 && ./configure && make -j2 install
 RUN rm -rf cmake-3.7.2.tar.gz cmake-3.7.2
 
 
@@ -15,7 +15,7 @@ RUN rm -rf cmake-3.7.2.tar.gz cmake-3.7.2
 # HDF5
 ############
 
-RUN wget --no-check-certificate https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.8/hdf5-1.8.17/src/hdf5-1.8.17.tar.bz2 && tar xfj hdf5-1.8.17.tar.bz2
+RUN curl -OL https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.8/hdf5-1.8.17/src/hdf5-1.8.17.tar.bz2 && tar xfj hdf5-1.8.17.tar.bz2
 RUN cd hdf5-1.8.17 && ./configure CFLAGS=-fPIC CXXFLAGS=-fPIC --prefix=/usr/local --with-pic --disable-shared --with-zlib=/usr/include/,/usr/lib64/ && make -j2 install
 
 # --disable-shared doesn't add libz to the archive, so it
@@ -29,7 +29,7 @@ RUN rm -rf hdf5-1.8.17.tar.bz2 hdf5-1.8.17
 # Boost
 ############
 
-RUN wget --no-check-certificate http://downloads.sourceforge.net/project/boost/boost/1.59.0/boost_1_59_0.tar.gz && tar xfz boost_1_59_0.tar.gz
+RUN curl -OL https://downloads.sourceforge.net/project/boost/boost/1.59.0/boost_1_59_0.tar.gz && tar xfz boost_1_59_0.tar.gz
 RUN cd boost_1_59_0 && ./bootstrap.sh --with-libraries=date_time,iostreams,filesystem,program_options,regex,serialization,system,test && ./b2 -j2 -q cxxflags=-fPIC cflags=-fPIC threading=multi link=static --build-type=minimal install
 RUN cd boost_1_59_0 && ./b2 --clean
 RUN rm -rf boost_1_59_0.tar.gz # don't delete build folder, needed to build boost.python for different python versions on-the-fly


### PR DESCRIPTION
The wget version of the VM is too old to establish a SSL connection, and this
is now needed to download hdf5.