### PR TITLE
Fix CMake run wrt python tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,7 +5,6 @@
 #
 # Change this number when adding tests to force a CMake run: 2
 
-add_subdirectory(brain/python)
 
 if(NOT BBPTESTDATA_FOUND)
   if(COMMON_ENABLE_COVERAGE)
@@ -26,3 +25,4 @@ endif()
 
 include(CommonCTest)
 
+add_subdirectory(brain/python)


### PR DESCRIPTION
CommonCTest adds the 'tests' target which is required for CommonPythonCTest,
hence it has to be included afterwards.