### PR TITLE
Adding Python 3.7 and removing 3.4 from wheels

### DIFF
--- a/packaging/python_wheels/common.sh
+++ b/packaging/python_wheels/common.sh
@@ -14,7 +14,7 @@ WORKSPACE=$(realpath $BASE/..)
 export http_proxy=${HTTP_PROXY-$http_proxy}
 export https_proxy=${HTTPS_PROXY-$https_proxy}
 
-NUMPY_VERSION=1.12.0
+NUMPY_VERSION=1.15.0
 SPHINX_VERSION=1.3.6
 
 popd

--- a/packaging/python_wheels/linux/Dockerfile
+++ b/packaging/python_wheels/linux/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/pypa/manylinux1_x86_64@sha256:a0f4dd1303b10dbbd99f84e6d7e9b6575efd5c3a6b16519a15703a70a5833b4d
+FROM quay.io/pypa/manylinux1_x86_64@sha256:b03e30ce7f306d711c6e60bf6cc3313fee40bfed84d2774deeb608fabc410031
 RUN yum install -y zlib-devel bzip2-devel flex
 
 ############
@@ -30,6 +30,7 @@ RUN rm -rf hdf5-1.8.17.tar.bz2 hdf5-1.8.17
 ############
 
 RUN curl -OL https://downloads.sourceforge.net/project/boost/boost/1.59.0/boost_1_59_0.tar.gz && tar xfz boost_1_59_0.tar.gz
+RUN cd boost_1_59_0 && sed -i -e "s/_PyUnicode_AsString/(void*)_PyUnicode_AsString/" libs/python/src/converter/builtin_converters.cpp
 RUN cd boost_1_59_0 && ./bootstrap.sh --with-libraries=date_time,iostreams,filesystem,program_options,regex,serialization,system,test && ./b2 -s NO_BZIP2=1 -j2 -q cxxflags=-fPIC cflags=-fPIC threading=multi link=static --build-type=minimal install
 RUN cd boost_1_59_0 && ./b2 --clean
 RUN rm -rf boost_1_59_0.tar.gz # don't delete build folder, needed to build boost.python for different python versions on-the-fly

--- a/packaging/python_wheels/linux/docker_build_wheel.sh
+++ b/packaging/python_wheels/linux/docker_build_wheel.sh
@@ -4,20 +4,20 @@ set -e
 cd "$( dirname "${BASH_SOURCE[0]}" )"
 source ../common.sh
 
-PYTHON_VERSIONS="cp27-cp27mu cp27-cp27m cp34-cp34m cp35-cp35m cp36-cp36m"
+PYTHON_VERSIONS="cp27-cp27mu cp27-cp27m cp35-cp35m cp36-cp36m cp37-cp37m"
 PACKAGING_DIR=/io/packaging/python_wheels/
 WHEELHOUSE=$PACKAGING_DIR/wheelhouse
 
 get_python_include()
 {
-    local PYTHON=$1; shift
+    local PYTHON=$1
     $PYTHON -c 'import distutils.sysconfig as s; print(s.get_python_inc())'
 }
 
 build_boost_python()
 {
-    local PYTHON=$1; shift
-    local PYTHON_INC=$1; shift
+    local PYTHON=$1
+    local PYTHON_INC=$2
 
     pushd /boost_1_59_0
 
@@ -37,7 +37,7 @@ build_boost_python()
 
 build_brain()
 {
-    local version=$1; shift
+    local version=$1
 
     local PYTHON=/opt/python/$version/bin/python
     local MAJOR_VERSION=$($PYTHON -c 'import sys; print(sys.version_info[0])')


### PR DESCRIPTION
Bumped numpy to version 1.15.0 because earlier versions fail to
build with Python 3.7.