### PR TITLE
Fixes and updates:

### DIFF
--- a/brion/plugin/compartmentReportCommon.cpp
+++ b/brion/plugin/compartmentReportCommon.cpp
@@ -55,7 +55,7 @@ size_t CompartmentReportCommon::_getFrameNumber(double timestamp) const
                  startTime) -
         startTime;
 
-    return size_t(timestamp / step);
+    return static_cast<size_t>(round(timestamp / step));
 }
 
 size_t CompartmentReportCommon::getFrameCount() const

--- a/brion/plugin/compartmentReportCommon.cpp
+++ b/brion/plugin/compartmentReportCommon.cpp
@@ -56,7 +56,7 @@ size_t CompartmentReportCommon::_getFrameNumber(double timestamp) const
         startTime;
 
     const double magnitude = round(1.0 / step);
-    return static_cast<uint64_t>(timestamp * magnitude);
+    return static_cast<size_t>(timestamp * magnitude);
 }
 
 size_t CompartmentReportCommon::getFrameCount() const

--- a/brion/plugin/compartmentReportCommon.cpp
+++ b/brion/plugin/compartmentReportCommon.cpp
@@ -55,7 +55,8 @@ size_t CompartmentReportCommon::_getFrameNumber(double timestamp) const
                  startTime) -
         startTime;
 
-    return static_cast<size_t>(round(timestamp / step));
+    const double magnitude = round(1.0 / step);
+    return static_cast<uint64_t>(timestamp * magnitude);
 }
 
 size_t CompartmentReportCommon::getFrameCount() const

--- a/brion/plugin/morphologyMORPHIO.cpp
+++ b/brion/plugin/morphologyMORPHIO.cpp
@@ -53,6 +53,7 @@ public:
     {
         auto& pluginManager = PluginLibrary::instance().getManager<MorphologyPlugin>();
         pluginManager.registerFactory<MorphologyMORPHIO>();
+        morphio::set_maximum_warnings(0);
     }
 };
 

--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -20,7 +20,7 @@ if(NOT glm_FOUND AND NOT TARGET glm)
       target_compile_options(glm INTERFACE -Wno-error=class-memaccess)
     endif()
     # Disable warnings
-    target_compile_options(glm PUBLIC -w)
+    target_compile_options(glm INTERFACE -w)
 endif()
 
 # --------------------------------------------------------------------------------

--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -19,6 +19,8 @@ if(NOT glm_FOUND AND NOT TARGET glm)
     if(CMAKE_COMPILER_IS_GNUCXX AND NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 8.0)
       target_compile_options(glm INTERFACE -Wno-error=class-memaccess)
     endif()
+    # Disable warnings
+    target_compile_options(glm PUBLIC -w)
 endif()
 
 # --------------------------------------------------------------------------------


### PR DESCRIPTION
- Fix wrong compartment report value caused by wrong frame index calculation from simulation timestamp
- Disabled warning output for morphio
- Disabled warnings for glm submodule