### PR TITLE
CMake: remove explicit setting of USE_PYTHON_VERSION.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,9 +69,6 @@ else()
     set(BRION_USE_CUSTOM_LIB_DIR ON)
 endif()
 
-# Configure used python version
-set(USE_PYTHON_VERSION 3)
-
 # Python wheels needed variables
 set(BRION_DESCRIPTION "The Blue Brain C++ I/O library")
 set(BRION_MAINTAINER_NAME "Blue Brain Project")


### PR DESCRIPTION
This variable is also set in `CMake/ChoosePython.cmake`, where the
default of `auto` leads to `__boost_python_library_suffix` being set.
That variable is used to set the right `USE_BOOST_PYTHON_VERSION`.

By overriding `USE_PYTHON_VERSION`, re-executing CMake will not enter
the Boost search loop and set `USE_BOOST_PYTHON_VERSION` to the empty
string.  If Python 2 should be discontinued, I think this would be best
done in `CMake/ChoosePython.cmake`.

Fixes #336.
