### PR TITLE
3.3.6 Release preparation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@
 
 # Base configuration
 cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
-project(Brion VERSION 3.3.5)
+project(Brion VERSION 3.3.6)
 set(Brion_VERSION_ABI 10)
 
 # Enforce C++14 standard

--- a/brain/python/brion/__init__.py
+++ b/brain/python/brion/__init__.py
@@ -22,7 +22,7 @@ from ._brion import *
 
 from . import neuron
 
-__version__ = '3.3.5'
+__version__ = '3.3.6'
 
 # Import the test helper module if present
 try:

--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -1,7 +1,7 @@
 Changelog {#Changelog}
 =========
 
-# Release 3.3.5
+# Release 3.3.6
 
 * [339](https://github.com/BlueBrain/Brion/pull/339)
   Set numpy minimun version to 1.19.5 and release preparation

--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -3,6 +3,11 @@ Changelog {#Changelog}
 
 # Release 3.3.5
 
+* [339](https://github.com/BlueBrain/Brion/pull/339)
+  Set numpy minimun version to 1.19.5 and release preparation
+
+# Release 3.3.5
+
 * [332](https://github.com/BlueBrain/Brion/pull/332)
   Improves submodule handling. Fix morphio target aliasing
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ from setuptools.command.test import test
 from distutils.version import LooseVersion
 
 
-REQUIRED_NUMPY_VERSION = "numpy>=1.7.0"
+REQUIRED_NUMPY_VERSION = "numpy>=1.19.5"
 MIN_CPU_CORES = 2
 
 


### PR DESCRIPTION
- Sets minimum required numpy version to 1.19.5
- 3.3.6 release preparation