### PR TITLE
Fix currentDir handling

### DIFF
--- a/brion/blueConfig.cpp
+++ b/brion/blueConfig.cpp
@@ -255,9 +255,15 @@ public:
         return std::string();
     }
 
-    const std::string& getCurrentDir()
+    const std::string getCurrentDir()
     {
-        return get(defaultSection, getDefaultSection(), BLUECONFIG_CURRENT_DIR_KEY);
+        std::string ret = get(defaultSection, getDefaultSection(), BLUECONFIG_CURRENT_DIR_KEY);
+
+        if(ret.empty()) {
+            ret = fs::system_complete(sourceParentPath).parent_path().string();
+        }
+
+        return ret;
     }
 
     const std::string getOutputRoot()


### PR DESCRIPTION
* if CurrentDir isn't in the BlueConfig, it should default to the path
  where the BlueConfig is, using the absolute path in this patch
* if a BlueConfig in the current directory is passed, `adjust_path`
  would be called with  ("BlueConfig", "", ".") if OutputPath  is "."
  this would return the `fullPath = currentDir + "/" + cleanPath; `
  `/.` since currentDir is empty, and this path exists.  This would mean
  the URI wasn't correct